### PR TITLE
Untrack hidden directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 .idea
+.vscode
 
 # Operating system related file
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ data/**
 
 # Embeddings
 .pretrained_embeddings_cache/
+.word_vectors_cache/
 
 # Test Files
 .pytest_cache


### PR DESCRIPTION
With the current *.gitignore*, the Visual Studio Code project settings are tracked with Git as well as the cached word embeddings. This PR adds both of them to *.gitignore*.

Since IntelliJ IDEA projects are already being ignored, I believe the same should apply to Visual Studio Code projects.

Similarly, the *.pretrained_embeddings_cache/* directory is being ignored while *.word_vectors_cache/* is not. Is it possible that *.pretrained_embeddings_cache/* was renamed to *.word_vectors_cache/* at some point during development?