### PR TITLE
Get vectors from token list

### DIFF
--- a/tests/word_to_vector/test_fast_text.py
+++ b/tests/word_to_vector/test_fast_text.py
@@ -46,10 +46,6 @@ def test_fasttext_list_arguments(mock_urlretrieve):
     list(vectors[['the', 'of']].shape) == [2, 300]
     list(vectors[('the', 'of')].shape) == [2, 300]
 
-    # Test implementation of __contains()__ for token list and tuple
-    assert ['the', 'of', 'a'] in vectors == [True, True, False]
-    assert ('the', 'of', 'a') in vectors == [True, True, False]
-
     # Clean up
     os.remove(os.path.join(directory, 'wiki.simple.vec.pt'))
 

--- a/tests/word_to_vector/test_fast_text.py
+++ b/tests/word_to_vector/test_fast_text.py
@@ -51,6 +51,30 @@ def test_fasttext_list_arguments(mock_urlretrieve):
 
 
 @mock.patch('urllib.request.urlretrieve')
+def test_fasttext_non_list_or_tuple_raises_type_error(mock_urlretrieve):
+    directory = 'tests/_test_data/fast_text/'
+
+    # Make sure URL has a 200 status
+    mock_urlretrieve.side_effect = urlretrieve_side_effect
+
+    # Load subset of FastText
+    vectors = FastText(language='simple', cache=directory)
+
+    # Test implementation of __getitem()__ for invalid type
+    error_class = None
+
+    try:
+        vectors[None]
+    except Exception as e:
+        error_class = e.__class__
+
+    assert error_class is TypeError
+
+    # Clean up
+    os.remove(os.path.join(directory, 'wiki.simple.vec.pt'))
+
+
+@mock.patch('urllib.request.urlretrieve')
 def test_aligned_fasttext(mock_urlretrieve):
     directory = 'tests/_test_data/fast_text/'
 

--- a/tests/word_to_vector/test_fast_text.py
+++ b/tests/word_to_vector/test_fast_text.py
@@ -33,6 +33,28 @@ def test_fasttext_simple(mock_urlretrieve):
 
 
 @mock.patch('urllib.request.urlretrieve')
+def test_fasttext_list_arguments(mock_urlretrieve):
+    directory = 'tests/_test_data/fast_text/'
+
+    # Make sure URL has a 200 status
+    mock_urlretrieve.side_effect = urlretrieve_side_effect
+
+    # Load subset of FastText
+    vectors = FastText(language='simple', cache=directory)
+
+    # Test implementation of __getitem()__ for token list and tuple
+    list(vectors[['the', 'of']].shape) == [2, 300]
+    list(vectors[('the', 'of')].shape) == [2, 300]
+
+    # Test implementation of __contains()__ for token list and tuple
+    assert ['the', 'of', 'a'] in vectors == [True, True, False]
+    assert ('the', 'of', 'a') in vectors == [True, True, False]
+
+    # Clean up
+    os.remove(os.path.join(directory, 'wiki.simple.vec.pt'))
+
+
+@mock.patch('urllib.request.urlretrieve')
 def test_aligned_fasttext(mock_urlretrieve):
     directory = 'tests/_test_data/fast_text/'
 

--- a/torchnlp/word_to_vector/pretrained_word_vectors.py
+++ b/torchnlp/word_to_vector/pretrained_word_vectors.py
@@ -74,7 +74,7 @@ class _PretrainedWordVectors(object):
     def __contains__(self, token):
         return token in self.stoi
 
-    def _get_token(self, token):
+    def _get_token_vector(self, token):
         """Return embedding for token or for UNK if token not in vocabulary"""
         if token in self.stoi:
             return self.vectors[self.stoi[token]]

--- a/torchnlp/word_to_vector/pretrained_word_vectors.py
+++ b/torchnlp/word_to_vector/pretrained_word_vectors.py
@@ -71,14 +71,33 @@ class _PretrainedWordVectors(object):
         self.name = name
         self.cache(name, cache, url=url)
 
-    def __contains__(self, token):
-        return token in self.stoi
+    def __contains__(self, tokens):
+        if isinstance(tokens, list) or isinstance(tokens, tuple):
+            return [token in self.stoi for token in tokens]
+        elif isinstance(tokens, str):
+            token = tokens
+            return token in self.stoi
+        else:
+            raise TypeError("'__contains__' method can only be used with types"
+                            "'str', 'list', or 'tuple' as parameter")
 
-    def __getitem__(self, token):
+    def _get_token(self, token):
+        """Return embedding for token or for UNK if token not in vocabulary"""
         if token in self.stoi:
             return self.vectors[self.stoi[token]]
         else:
             return self.unk_init(torch.Tensor(self.dim))
+
+    def __getitem__(self, tokens):
+        if isinstance(tokens, list) or isinstance(tokens, tuple):
+            vector_list = [self._get_token(token) for token in tokens]
+            return torch.stack(vector_list)
+        elif isinstance(tokens, str):
+            token = tokens
+            return self._get_token(token)
+        else:
+            raise TypeError("'__getitem__' method can only be used with types"
+                            "'str', 'list', or 'tuple' as parameter")
 
     def __len__(self):
         return len(self.vectors)

--- a/torchnlp/word_to_vector/pretrained_word_vectors.py
+++ b/torchnlp/word_to_vector/pretrained_word_vectors.py
@@ -83,11 +83,11 @@ class _PretrainedWordVectors(object):
 
     def __getitem__(self, tokens):
         if isinstance(tokens, list) or isinstance(tokens, tuple):
-            vector_list = [self._get_token(token) for token in tokens]
+            vector_list = [self._get_token_vector(token) for token in tokens]
             return torch.stack(vector_list)
         elif isinstance(tokens, str):
             token = tokens
-            return self._get_token(token)
+            return self._get_token_vector(token)
         else:
             raise TypeError("'__getitem__' method can only be used with types"
                             "'str', 'list', or 'tuple' as parameter")

--- a/torchnlp/word_to_vector/pretrained_word_vectors.py
+++ b/torchnlp/word_to_vector/pretrained_word_vectors.py
@@ -71,15 +71,8 @@ class _PretrainedWordVectors(object):
         self.name = name
         self.cache(name, cache, url=url)
 
-    def __contains__(self, tokens):
-        if isinstance(tokens, list) or isinstance(tokens, tuple):
-            return [token in self.stoi for token in tokens]
-        elif isinstance(tokens, str):
-            token = tokens
-            return token in self.stoi
-        else:
-            raise TypeError("'__contains__' method can only be used with types"
-                            "'str', 'list', or 'tuple' as parameter")
+    def __contains__(self, token):
+        return token in self.stoi
 
     def _get_token(self, token):
         """Return embedding for token or for UNK if token not in vocabulary"""


### PR DESCRIPTION
This PR extends the `__getitem()__` method of the `_PretrainedWordVectors` base class for `list` and `tuple` types in order to retrieve word vectors for multiple tokens at once.

It also adds unit tests to assert that retrieval for mutiple tokens works correctly and an exception is thrown for invalid types.

For example, the following code will return a 4x300 `torch.FloatTensor` object:
```python
from torchnlp.word_to_vector import FastText
vectors = FastText()
tokenized_sentence = ['this', 'is', 'a', 'sentence']
vectors[tokenized_sentence]
```