### PR TITLE
remove lambdas for pickle

### DIFF
--- a/tests/samplers/test_bptt_batch_sampler.py
+++ b/tests/samplers/test_bptt_batch_sampler.py
@@ -1,19 +1,31 @@
+import pickle
+import string
+
+import pytest
+
 from torchnlp.samplers import BPTTBatchSampler
 from torchnlp.utils import sampler_to_iterator
 
 
-def test_bptt_batch_sampler_drop_last():
+@pytest.fixture
+def alphabet():
+    return list(string.ascii_lowercase)
+
+
+@pytest.fixture
+def sampler(alphabet):
+    return BPTTBatchSampler(alphabet, bptt_length=2, batch_size=4, drop_last=True)
+
+
+def test_bptt_batch_sampler_drop_last(sampler, alphabet):
     # Test samplers iterate over chunks similar to:
     # https://github.com/pytorch/examples/blob/c66593f1699ece14a4a2f4d314f1afb03c6793d9/word_language_model/main.py#L112
-    alphabet = list('abcdefghijklmnopqrstuvwxyz')
-    sampler = BPTTBatchSampler(alphabet, bptt_length=2, batch_size=4, drop_last=True)
     list_ = list(sampler_to_iterator(alphabet, sampler))
     assert list_[0] == [['a', 'b'], ['g', 'h'], ['m', 'n'], ['s', 't']]
     assert len(sampler) == len(list_)
 
 
-def test_bptt_batch_sampler():
-    alphabet = list('abcdefghijklmnopqrstuvwxyz')
+def test_bptt_batch_sampler(alphabet):
     sampler = BPTTBatchSampler(alphabet, bptt_length=2, batch_size=4, drop_last=False)
     list_ = list(sampler_to_iterator(alphabet, sampler))
     assert list_[0] == [['a', 'b'], ['h', 'i'], ['o', 'p'], ['u', 'v']]
@@ -27,3 +39,7 @@ def test_bptt_batch_sampler_example():
     sampler = BPTTBatchSampler(
         range(100), bptt_length=2, batch_size=3, drop_last=False, type_='target')
     assert list(sampler)[0] == [slice(1, 3), slice(35, 37), slice(68, 70)]
+
+
+def test_is_pickleable(sampler):
+    pickle.dumps(sampler)

--- a/tests/samplers/test_bptt_sampler.py
+++ b/tests/samplers/test_bptt_sampler.py
@@ -1,10 +1,17 @@
+import pickle
 import random
+
+import pytest
 
 from torchnlp.samplers import BPTTSampler
 
 
-def test_bptt_sampler_odd():
-    sampler = BPTTSampler(range(5), 2)
+@pytest.fixture
+def sampler():
+    return BPTTSampler(range(5), 2)
+
+
+def test_bptt_sampler_odd(sampler):
     assert list(sampler) == [slice(0, 2), slice(2, 4)]
     assert len(sampler) == 2
 
@@ -19,3 +26,7 @@ def test_bptt_sampler_length():
     for i in range(1, 1000):
         sampler = BPTTSampler(range(i), random.randint(1, 17))
         assert len(sampler) == len(list(sampler))
+
+
+def test_is_pickleable(sampler):
+    pickle.dumps(sampler)

--- a/tests/samplers/test_bucket_batch_sampler.py
+++ b/tests/samplers/test_bucket_batch_sampler.py
@@ -1,5 +1,6 @@
-import torch
+import pickle
 
+import torch
 from torchnlp.samplers import BucketBatchSampler
 
 
@@ -56,3 +57,9 @@ def test_bucket_batch_sampler_sorted():
     # Largest batch (4) is in first batch
     for i, batch in enumerate(batches):
         assert batch[0] == i
+
+
+def test_pickleable():
+    data_source = [[1], [2], [3], [4], [5]]
+    sampler = BucketBatchSampler(data_source, batch_size=2, drop_last=False)
+    pickle.dumps(sampler)

--- a/tests/samplers/test_noisy_sorted_batch_sampler.py
+++ b/tests/samplers/test_noisy_sorted_batch_sampler.py
@@ -1,3 +1,5 @@
+import pickle
+
 from torchnlp.samplers import NoisySortedBatchSampler
 
 
@@ -49,3 +51,10 @@ def test_noisy_sorted_batch_sampler_sorted():
     # Largest batch (4) is in first batch
     for i, batch in enumerate(batches):
         assert batch[0] == i
+
+
+def test_pickleable():
+    data_source = [[1], [2], [3], [4], [5], [6]]
+    sampler = NoisySortedBatchSampler(data_source, batch_size=2, drop_last=False)
+    pickle.dumps(sampler)
+

--- a/tests/samplers/test_noisy_sorted_batch_sampler.py
+++ b/tests/samplers/test_noisy_sorted_batch_sampler.py
@@ -57,4 +57,3 @@ def test_pickleable():
     data_source = [[1], [2], [3], [4], [5], [6]]
     sampler = NoisySortedBatchSampler(data_source, batch_size=2, drop_last=False)
     pickle.dumps(sampler)
-

--- a/tests/samplers/test_noisy_sorted_sampler.py
+++ b/tests/samplers/test_noisy_sorted_sampler.py
@@ -1,3 +1,5 @@
+import pickle
+
 from torchnlp.samplers import NoisySortedSampler
 
 
@@ -24,3 +26,9 @@ def test_noisy_sorted_sampler_sort_key_noise():
     indexes = list(NoisySortedSampler(data_source, sort_key=sort_key, sort_key_noise=0.25))
     for i, j in enumerate(indexes):
         assert i == j
+
+
+def test_pickleable():
+    data_source = [[1], [2], [3], [4], [5], [6]]
+    sampler = NoisySortedSampler(data_source)
+    pickle.dumps(sampler)

--- a/tests/samplers/test_shuffle_batch_sampler.py
+++ b/tests/samplers/test_shuffle_batch_sampler.py
@@ -1,3 +1,5 @@
+import pickle
+
 from torchnlp.samplers import ShuffleBatchSampler
 
 from torchnlp.samplers import SortedSampler
@@ -20,3 +22,9 @@ def test_shuffle_batch_sampler_drop_last():
         ShuffleBatchSampler(
             SortedSampler(data_source, sort_key=sort_key), batch_size, drop_last=True))
     assert len(batches) == 2
+
+
+def test_pickleable():
+    data_source = [[1], [2], [3], [4], [5], [6]]
+    sampler = ShuffleBatchSampler(SortedSampler(data_source), batch_size=2, drop_last=False)
+    pickle.dumps(sampler)

--- a/tests/samplers/test_sorted_sampler.py
+++ b/tests/samplers/test_sorted_sampler.py
@@ -1,3 +1,5 @@
+import pickle
+
 from torchnlp.samplers import SortedSampler
 
 
@@ -8,3 +10,9 @@ def test_sorted_sampler():
     assert len(indexes) == len(data_source)
     for i, j in enumerate(indexes):
         assert i == j
+
+
+def test_pickleable():
+    data_source = [[1], [2], [3], [4], [5], [6]]
+    sampler = SortedSampler(data_source)
+    pickle.dumps(sampler)

--- a/tests/text_encoders/test_character_encoder.py
+++ b/tests/text_encoders/test_character_encoder.py
@@ -1,11 +1,23 @@
+import pickle
+
+import pytest
+
 from torchnlp.text_encoders import CharacterEncoder
 from torchnlp.text_encoders import UNKNOWN_TOKEN
 from torchnlp.text_encoders.reserved_tokens import RESERVED_ITOS
 
 
-def test_character_encoder():
-    sample = ['The quick brown fox jumps over the lazy dog']
-    encoder = CharacterEncoder(sample)
+@pytest.fixture
+def sample():
+    return ['The quick brown fox jumps over the lazy dog']
+
+
+@pytest.fixture
+def encoder(sample):
+    return CharacterEncoder(sample)
+
+
+def test_character_encoder(encoder, sample):
     input_ = 'english-language pangram'
     output = encoder.encode(input_)
     assert encoder.vocab_size == len(set(list(sample[0]))) + len(RESERVED_ITOS)
@@ -13,9 +25,12 @@ def test_character_encoder():
     assert encoder.decode(output) == input_.replace('-', UNKNOWN_TOKEN)
 
 
-def test_character_encoder_min_occurrences():
-    sample = ['The quick brown fox jumps over the lazy dog']
+def test_character_encoder_min_occurrences(sample):
     encoder = CharacterEncoder(sample, min_occurrences=10)
     input_ = 'English-language pangram'
     output = encoder.encode(input_)
     assert encoder.decode(output) == ''.join([UNKNOWN_TOKEN] * len(input_))
+
+
+def test_is_pickleable(encoder):
+    pickle.dumps(encoder)

--- a/tests/text_encoders/test_delimiter_encoder.py
+++ b/tests/text_encoders/test_delimiter_encoder.py
@@ -1,11 +1,23 @@
+import pickle
+
+import pytest
+
 from torchnlp.text_encoders import DelimiterEncoder
 from torchnlp.text_encoders import UNKNOWN_TOKEN
 from torchnlp.text_encoders import EOS_TOKEN
 
 
-def test_delimiter_encoder():
+@pytest.fixture
+def encoder():
     sample = ['people/deceased_person/place_of_death', 'symbols/name_source/namesakes']
-    encoder = DelimiterEncoder('/', sample, append_eos=True)
+    return DelimiterEncoder('/', sample, append_eos=True)
+
+
+def test_delimiter_encoder(encoder):
     input_ = 'symbols/namesake/named_after'
     output = encoder.encode(input_)
     assert encoder.decode(output) == '/'.join(['symbols', UNKNOWN_TOKEN, UNKNOWN_TOKEN]) + EOS_TOKEN
+
+
+def test_is_pickleable(encoder):
+    pickle.dumps(encoder)

--- a/tests/text_encoders/test_identity_encoder.py
+++ b/tests/text_encoders/test_identity_encoder.py
@@ -1,10 +1,18 @@
+import pickle
+
+import pytest
+
 from torchnlp.text_encoders import IdentityEncoder
 from torchnlp.text_encoders import UNKNOWN_TOKEN
 
 
-def test_identity_encoder_unknown():
+@pytest.fixture
+def encoder():
     sample = ['people/deceased_person/place_of_death', 'symbols/name_source/namesakes']
-    encoder = IdentityEncoder(sample)
+    return IdentityEncoder(sample)
+
+
+def test_identity_encoder_unknown(encoder):
     input_ = 'symbols/namesake/named_after'
     output = encoder.encode(input_)
     assert len(output) == 1
@@ -21,10 +29,12 @@ def test_identity_encoder_known():
     assert encoder.decode(output) == input_
 
 
-def test_identity_encoder_sequence():
+def test_identity_encoder_sequence(encoder):
     input_ = ['symbols/namesake/named_after', 'people/deceased_person/place_of_death']
-    sample = ['people/deceased_person/place_of_death', 'symbols/name_source/namesakes']
-    encoder = IdentityEncoder(sample)
     output = encoder.encode(input_)
     assert len(output) == 2
     assert encoder.decode(output) == [UNKNOWN_TOKEN, 'people/deceased_person/place_of_death']
+
+
+def test_is_pickleable(encoder):
+    pickle.dumps(encoder)

--- a/tests/text_encoders/test_moses_encoder.py
+++ b/tests/text_encoders/test_moses_encoder.py
@@ -1,11 +1,23 @@
+import pickle
+
+import pytest
+
 from torchnlp.text_encoders import MosesEncoder
 
 
-def test_moses_encoder():
+@pytest.fixture
+def input_():
+    return ("This ain't funny. It's actually hillarious, yet double Ls. | [] < > [ ] & " +
+            "You're gonna shake it off? Don't?")
+
+
+@pytest.fixture
+def encoder(input_):
+    return MosesEncoder([input_])
+
+
+def test_moses_encoder(encoder, input_):
     # TEST adapted from example in http://www.nltk.org/_modules/nltk/tokenize/moses.html
-    input_ = ("This ain't funny. It's actually hillarious, yet double Ls. | [] < > [ ] & " +
-              "You're gonna shake it off? Don't?")
-    encoder = MosesEncoder([input_])
     expected_tokens = [
         'This', 'ain', '&apos;t', 'funny', '.', 'It', '&apos;s', 'actually', 'hillarious', ',',
         'yet', 'double', 'Ls', '.', '&#124;', '&#91;', '&#93;', '&lt;', '&gt;', '&#91;', '&#93;',
@@ -16,3 +28,7 @@ def test_moses_encoder():
     tokens = encoder.encode(input_)
     assert [encoder.itos[i] for i in tokens] == expected_tokens
     assert encoder.decode(tokens) == expected_decode
+
+
+def test_is_pickleable(encoder):
+    pickle.dumps(encoder)

--- a/tests/text_encoders/test_spacy_encoder.py
+++ b/tests/text_encoders/test_spacy_encoder.py
@@ -1,9 +1,18 @@
+import pickle
+
+import pytest
+
 from torchnlp.text_encoders import SpacyEncoder
 
 
-def test_spacy_encoder():
+@pytest.fixture
+def encoder():
     input_ = 'This is a sentence'
-    encoder = SpacyEncoder([input_])
+    return SpacyEncoder([input_])
+
+
+def test_spacy_encoder(encoder):
+    input_ = 'This is a sentence'
     tokens = encoder.encode(input_)
     assert encoder.decode(tokens) == input_
 
@@ -27,3 +36,7 @@ def test_spacy_encoder_unsupported_language():
 
     assert error_message.startswith("No tokenizer available for language " +
                                     "'python'.")
+
+
+def test_is_pickleable(encoder):
+    pickle.dumps(encoder)

--- a/tests/text_encoders/test_static_tokenizer_encoder.py
+++ b/tests/text_encoders/test_static_tokenizer_encoder.py
@@ -1,0 +1,24 @@
+import pickle
+
+import pytest
+
+from torchnlp.text_encoders import StaticTokenizerEncoder
+
+
+@pytest.fixture
+def input_():
+    return 'This is a sentence'
+
+
+@pytest.fixture
+def encoder(input_):
+    return StaticTokenizerEncoder([input_])
+
+
+def test_static_tokenizer_encoder(encoder, input_):
+    tokens = encoder.encode(input_)
+    assert encoder.decode(tokens) == input_
+
+
+def test_is_pickleable(encoder):
+    pickle.dumps(encoder)

--- a/tests/text_encoders/test_subword_encoder.py
+++ b/tests/text_encoders/test_subword_encoder.py
@@ -6,7 +6,8 @@ from torchnlp.text_encoders import SubwordEncoder
 from torchnlp.text_encoders import EOS_INDEX
 
 
-class SubwordEncoderTest:
+class TestSubwordEncoder:
+
     @pytest.fixture(scope='module')
     def corpus(self):
         return [
@@ -17,8 +18,7 @@ class SubwordEncoderTest:
 
     @pytest.fixture
     def encoder(self, corpus):
-        return SubwordEncoder(
-            corpus, target_vocab_size=86, min_occurrences=2, max_occurrences=6)
+        return SubwordEncoder(corpus, target_vocab_size=86, min_occurrences=2, max_occurrences=6)
 
     def test_build_vocab_target_size(self, encoder):
         # NOTE: `target_vocab_size` is approximate; therefore, it may not be exactly the target size

--- a/tests/text_encoders/test_subword_encoder.py
+++ b/tests/text_encoders/test_subword_encoder.py
@@ -1,31 +1,37 @@
-import unittest
+import pickle
+
+import pytest
 
 from torchnlp.text_encoders import SubwordEncoder
 from torchnlp.text_encoders import EOS_INDEX
 
 
-class SubwordEncoderTest(unittest.TestCase):
-
-    def setUp(self):
-        self.corpus = [
+class SubwordEncoderTest:
+    @pytest.fixture(scope='module')
+    def corpus(self):
+        return [
             "One morning I shot an elephant in my pajamas. How he got in my pajamas, I don't",
             'know.', '', 'Groucho Marx',
             "I haven't slept for 10 days... because that would be too long.", '', 'Mitch Hedberg'
         ]
 
-    def test_build_vocab_target_size(self):
+    @pytest.fixture
+    def encoder(self, corpus):
+        return SubwordEncoder(
+            corpus, target_vocab_size=86, min_occurrences=2, max_occurrences=6)
+
+    def test_build_vocab_target_size(self, encoder):
         # NOTE: `target_vocab_size` is approximate; therefore, it may not be exactly the target size
-        encoder = SubwordEncoder(
-            self.corpus, target_vocab_size=86, min_occurrences=2, max_occurrences=6)
         assert len(encoder.vocab) == 86
 
-    def test_encode(self):
-        encoder = SubwordEncoder(
-            self.corpus, target_vocab_size=86, min_occurrences=2, max_occurrences=6)
+    def test_encode(self, encoder):
         input_ = 'This has UPPER CASE letters that are out of alphabet'
         assert encoder.decode(encoder.encode(input_)) == input_
 
-    def test_eos(self):
-        encoder = SubwordEncoder(self.corpus, append_eos=True)
+    def test_eos(self, corpus):
+        encoder = SubwordEncoder(corpus, append_eos=True)
         input_ = 'This is a sentence'
         assert encoder.encode(input_)[-1] == EOS_INDEX
+
+    def test_is_pickleable(self, encoder):
+        pickle.dumps(encoder)

--- a/tests/text_encoders/test_subword_tokenizer.py
+++ b/tests/text_encoders/test_subword_tokenizer.py
@@ -1,5 +1,6 @@
 import unittest
 import collections
+import pickle
 import random
 import mock
 
@@ -167,3 +168,8 @@ class SubwordTextTokenizerTest(unittest.TestCase):
         # Previously there was a bug which produced an infinite loop in this case.
         with self.assertRaises(AssertionError):
             encoder.encode(original)
+
+
+def test_is_pickleable():
+    tokenizer = SubwordTextTokenizer()
+    pickle.dumps(tokenizer)

--- a/tests/text_encoders/test_treebank_encoder.py
+++ b/tests/text_encoders/test_treebank_encoder.py
@@ -1,10 +1,22 @@
+import pickle
+
+import pytest
+
 from torchnlp.text_encoders import TreebankEncoder
 
 
-def test_treebank_encoder():
+@pytest.fixture
+def input_():
+    return '''Good muffins cost $3.88\nin New York.  Please buy me\ntwo of them.\nThanks.'''
+
+
+@pytest.fixture
+def encoder(input_):
+    return TreebankEncoder([input_])
+
+
+def test_treebank_encoder(encoder, input_):
     # TEST adapted from example in http://www.nltk.org/_modules/nltk/tokenize/treebank.html
-    input_ = '''Good muffins cost $3.88\nin New York.  Please buy me\ntwo of them.\nThanks.'''
-    encoder = TreebankEncoder([input_])
     expected_tokens = [
         'Good', 'muffins', 'cost', '$', '3.88', 'in', 'New', 'York.', 'Please', 'buy', 'me', 'two',
         'of', 'them.', 'Thanks', '.'
@@ -13,3 +25,7 @@ def test_treebank_encoder():
     tokens = encoder.encode(input_)
     assert [encoder.itos[i] for i in tokens] == expected_tokens
     assert encoder.decode(tokens) == expected_decode
+
+
+def test_is_pickleable(encoder):
+    pickle.dumps(encoder)

--- a/tests/text_encoders/test_word_encoder.py
+++ b/tests/text_encoders/test_word_encoder.py
@@ -1,8 +1,24 @@
+import pickle
+
+import pytest
+
 from torchnlp.text_encoders import WhitespaceEncoder
 
 
-def test_spacy_encoder():
-    input_ = 'This is a sentence'
-    encoder = WhitespaceEncoder([input_])
+@pytest.fixture
+def input_():
+    return 'This is a sentence'
+
+
+@pytest.fixture
+def encoder(input_):
+    return WhitespaceEncoder([input_])
+
+
+def test_whitespace_encoder(encoder, input_):
     tokens = encoder.encode(input_)
     assert encoder.decode(tokens) == input_
+
+
+def test_is_pickleable(encoder):
+    pickle.dumps(encoder)

--- a/torchnlp/samplers/bucket_batch_sampler.py
+++ b/torchnlp/samplers/bucket_batch_sampler.py
@@ -9,6 +9,14 @@ from torchnlp.samplers.shuffle_batch_sampler import ShuffleBatchSampler
 from torchnlp.utils import get_tensors
 
 
+def _biggest_batches_first(o):
+    return sum([t.numel() for t in get_tensors(o)])
+
+
+def _identity(e):
+    return e
+
+
 class BucketBatchSampler(object):
     """Batches are sampled from sorted buckets of data.
 
@@ -62,8 +70,8 @@ class BucketBatchSampler(object):
             data,
             batch_size,
             drop_last,
-            sort_key=lambda e: e,
-            biggest_batches_first=lambda o: sum([t.numel() for t in get_tensors(o)]),
+            sort_key=_identity,
+            biggest_batches_first=_biggest_batches_first,
             bucket_size_multiplier=100,
             shuffle=True,
     ):

--- a/torchnlp/samplers/noisy_sorted_batch_sampler.py
+++ b/torchnlp/samplers/noisy_sorted_batch_sampler.py
@@ -5,6 +5,10 @@ from torch.utils.data.sampler import BatchSampler
 from torchnlp.samplers.noisy_sorted_sampler import NoisySortedSampler
 
 
+def _first(e):
+    return e[0]
+
+
 class NoisySortedBatchSampler(BatchSampler):
     """ Batch of indices are sampled from a noisy sorting of the data.
 
@@ -56,7 +60,7 @@ class NoisySortedBatchSampler(BatchSampler):
                  data,
                  batch_size,
                  drop_last,
-                 sort_key=lambda e: e,
+                 sort_key=_first,
                  sort_key_noise=0.25,
                  last_batch_first=True,
                  shuffle=True):

--- a/torchnlp/samplers/noisy_sorted_sampler.py
+++ b/torchnlp/samplers/noisy_sorted_sampler.py
@@ -3,6 +3,10 @@ import random
 from torch.utils.data.sampler import Sampler
 
 
+def _first(e):
+    return e[0]
+
+
 class NoisySortedSampler(Sampler):
     """Samples elements sequentially with noise.
 
@@ -20,7 +24,7 @@ class NoisySortedSampler(Sampler):
         [0, 1, 2, 3, 4, 5, 8, 6, 7, 9]
     """
 
-    def __init__(self, data, sort_key=lambda e: e, sort_key_noise=0.25):
+    def __init__(self, data, sort_key=_first, sort_key_noise=0.25):
         super().__init__(data)
         self.data = data
         self.sort_key = sort_key

--- a/torchnlp/samplers/sorted_sampler.py
+++ b/torchnlp/samplers/sorted_sampler.py
@@ -1,6 +1,10 @@
 from torch.utils.data.sampler import Sampler
 
 
+def _identity(e):
+    return e
+
+
 class SortedSampler(Sampler):
     """Samples elements sequentially, always in the same order.
 
@@ -15,7 +19,7 @@ class SortedSampler(Sampler):
 
     """
 
-    def __init__(self, data, sort_key=lambda e: e):
+    def __init__(self, data, sort_key=_identity):
         super().__init__(data)
         self.data = data
         self.sort_key = sort_key

--- a/torchnlp/text_encoders/character_encoder.py
+++ b/torchnlp/text_encoders/character_encoder.py
@@ -1,6 +1,10 @@
 from torchnlp.text_encoders.static_tokenizer_encoder import StaticTokenizerEncoder
 
 
+def _tokenize(s):
+    return list(s)
+
+
 class CharacterEncoder(StaticTokenizerEncoder):
     """ Encodes text into a tensor by splitting the text into individual characters.
 
@@ -14,7 +18,7 @@ class CharacterEncoder(StaticTokenizerEncoder):
     def __init__(self, *args, **kwargs):
         if 'tokenize' in kwargs:
             raise TypeError('CharacterEncoder defines a tokenize callable per character')
-        super().__init__(*args, tokenize=(lambda s: list(s)), **kwargs)
+        super().__init__(*args, tokenize=_tokenize, **kwargs)
 
     def decode(self, tensor):
         tokens = [self.itos[index] for index in tensor]

--- a/torchnlp/text_encoders/delimiter_encoder.py
+++ b/torchnlp/text_encoders/delimiter_encoder.py
@@ -1,5 +1,11 @@
+from functools import partial
+
 from torchnlp.text_encoders.static_tokenizer_encoder import StaticTokenizerEncoder
 from torchnlp.text_encoders.reserved_tokens import UNKNOWN_TOKEN
+
+
+def _tokenize(s, delimiter):
+    return s.split(delimiter)
 
 
 class DelimiterEncoder(StaticTokenizerEncoder):
@@ -27,7 +33,7 @@ class DelimiterEncoder(StaticTokenizerEncoder):
         if 'tokenize' in kwargs:
             raise TypeError('CharacterEncoder defines a tokenize callable per character')
         self.delimiter = delimiter
-        super().__init__(*args, tokenize=(lambda s: s.split(delimiter)), **kwargs)
+        super().__init__(*args, tokenize=partial(_tokenize, delimiter=self.delimiter), **kwargs)
 
     def decode(self, tensor):
         tokens = [self.itos[index] for index in tensor]

--- a/torchnlp/text_encoders/identity_encoder.py
+++ b/torchnlp/text_encoders/identity_encoder.py
@@ -1,6 +1,10 @@
 from torchnlp.text_encoders.static_tokenizer_encoder import StaticTokenizerEncoder
 
 
+def _tokenize(s):
+    return s if isinstance(s, list) else [s]
+
+
 class IdentityEncoder(StaticTokenizerEncoder):
     """ Encodes the text without tokenization.
 
@@ -34,7 +38,7 @@ class IdentityEncoder(StaticTokenizerEncoder):
             raise TypeError('IdentityEncoder defines a identity tokenization')
         if 'append_eos' not in kwargs:
             kwargs['append_eos'] = False  # Default to not appending EOS
-        super().__init__(*args, tokenize=(lambda s: s if isinstance(s, list) else [s]), **kwargs)
+        super().__init__(*args, tokenize=_tokenize, **kwargs)
 
     def decode(self, tensor):
         tokens = [self.itos[index] for index in tensor]

--- a/torchnlp/text_encoders/spacy_encoder.py
+++ b/torchnlp/text_encoders/spacy_encoder.py
@@ -1,4 +1,10 @@
+from functools import partial
+
 from torchnlp.text_encoders.static_tokenizer_encoder import StaticTokenizerEncoder
+
+
+def _tokenize(s, tokenizer):
+    return [w.text for w in tokenizer(s)]
 
 
 class SpacyEncoder(StaticTokenizerEncoder):
@@ -67,4 +73,4 @@ class SpacyEncoder(StaticTokenizerEncoder):
                               "Currently supported are %s")
                              % (language, supported_languages))
 
-        super().__init__(*args, tokenize=lambda s: [w.text for w in tokenizer(s)], **kwargs)
+        super().__init__(*args, tokenize=partial(_tokenize, tokenizer=tokenizer), **kwargs)

--- a/torchnlp/text_encoders/static_tokenizer_encoder.py
+++ b/torchnlp/text_encoders/static_tokenizer_encoder.py
@@ -8,23 +8,19 @@ from torchnlp.text_encoders.reserved_tokens import RESERVED_ITOS
 from torchnlp.text_encoders.text_encoder import TextEncoder
 
 
-def _split(s):
+def _tokenize(s):
     return s.split()
 
 
-def _identity(s):
-    return s
-
-
 class StaticTokenizerEncoder(TextEncoder):
-    """ Encodes the text using a custom tokenizer.
+    """ Encodes the text using a tokenizer.
 
     Args:
-        sample (list of strings): Sample of data to build dictionary on
+        sample (list of strings): Sample of data to build dictionary on.
         min_occurrences (int, optional): Minimum number of occurrences for a token to be added to
           dictionary.
+        tokenize (callable): :class:``callable`` to tokenize a string.
         append_eos (bool, optional): If `True` append EOS token onto the end to the encoded vector.
-        tokenize (callable): callable to tokenize a string
         reserved_tokens (list of str, optional): Tokens added to dictionary; reserving the first
             `len(reserved_tokens)` indexes.
 
@@ -48,14 +44,14 @@ class StaticTokenizerEncoder(TextEncoder):
                  sample,
                  min_occurrences=1,
                  append_eos=False,
-                 tokenize=_split,
+                 tokenize=_tokenize,
                  reserved_tokens=RESERVED_ITOS):
         if not isinstance(sample, list):
             raise TypeError('Sample must be a list of strings.')
 
+        self.tokenize = tokenize
         self.append_eos = append_eos
         self.tokens = Counter()
-        self.tokenize = tokenize if tokenize else _identity
 
         for text in sample:
             self.tokens.update(self.tokenize(text))

--- a/torchnlp/text_encoders/static_tokenizer_encoder.py
+++ b/torchnlp/text_encoders/static_tokenizer_encoder.py
@@ -8,8 +8,16 @@ from torchnlp.text_encoders.reserved_tokens import RESERVED_ITOS
 from torchnlp.text_encoders.text_encoder import TextEncoder
 
 
+def _split(s):
+    return s.split()
+
+
+def _identity(s):
+    return s
+
+
 class StaticTokenizerEncoder(TextEncoder):
-    """ Encodes the text using a lambda tokenizer.
+    """ Encodes the text using a custom tokenizer.
 
     Args:
         sample (list of strings): Sample of data to build dictionary on
@@ -40,14 +48,14 @@ class StaticTokenizerEncoder(TextEncoder):
                  sample,
                  min_occurrences=1,
                  append_eos=False,
-                 tokenize=(lambda s: s.split()),
+                 tokenize=_split,
                  reserved_tokens=RESERVED_ITOS):
         if not isinstance(sample, list):
             raise TypeError('Sample must be a list of strings.')
 
         self.append_eos = append_eos
         self.tokens = Counter()
-        self.tokenize = tokenize if tokenize else lambda x: x
+        self.tokenize = tokenize if tokenize else _identity
 
         for text in sample:
             self.tokens.update(self.tokenize(text))

--- a/torchnlp/text_encoders/whitespace_encoder.py
+++ b/torchnlp/text_encoders/whitespace_encoder.py
@@ -1,6 +1,10 @@
 from torchnlp.text_encoders.static_tokenizer_encoder import StaticTokenizerEncoder
 
 
+def _tokenize(s):
+    return s.split()
+
+
 class WhitespaceEncoder(StaticTokenizerEncoder):
     """ Encodes the text by splitting on whitespace.
 
@@ -32,7 +36,7 @@ class WhitespaceEncoder(StaticTokenizerEncoder):
     def __init__(self, *args, **kwargs):
         if 'tokenize' in kwargs:
             raise TypeError('WhiteSpaceEncoder defines a tokenize callable per character')
-        super().__init__(*args, tokenize=(lambda s: s.split()), **kwargs)
+        super().__init__(*args, tokenize=_tokenize, **kwargs)
 
     def decode(self, tensor):
         tokens = [self.itos[index] for index in tensor]


### PR DESCRIPTION
lambda cannot be pickled, therefore it is better to not use it as attribute. Even though there are alternatives to pickle, some libraries use pickle internally, which is why it's better to support it.

Tests were added to all samplers and encoders for whether objects can be pickled.