### PR TITLE
Update Encoder specification; Bump version to 0.4.1

### DIFF
--- a/tests/encoders/test_encoder.py
+++ b/tests/encoders/test_encoder.py
@@ -1,0 +1,7 @@
+from torchnlp.encoders import Encoder
+
+
+def test_encoder():
+    encoder = Encoder(enforce_reversible=True)
+    encoder.encode('this is a test')
+    encoder.decode('this is a test')

--- a/tests/encoders/test_label_encoder.py
+++ b/tests/encoders/test_label_encoder.py
@@ -25,7 +25,7 @@ def test_label_encoder_no_reserved():
 
 
 def test_label_encoder_enforce_reversible(label_encoder):
-    label_encoder.enforce_reversible()
+    label_encoder.enforce_reversible = True
 
     label_encoder.encode('people/deceased_person/place_of_death')
     with pytest.raises(ValueError):
@@ -39,6 +39,12 @@ def test_label_encoder_enforce_reversible(label_encoder):
 def test_label_encoder_batch_encoding(label_encoder):
     encoded = label_encoder.batch_encode(label_encoder.vocab)
     assert torch.equal(encoded, torch.arange(label_encoder.vocab_size).view(-1))
+
+
+def test_label_encoder_batch_dim(label_encoder):
+    encoded = label_encoder.batch_encode(label_encoder.vocab, dim=-1)
+    decoded = label_encoder.batch_decode(encoded, dim=-1)
+    assert decoded == label_encoder.vocab
 
 
 def test_label_encoder_batch_decoding(label_encoder):

--- a/tests/encoders/text/test_spacy_encoder.py
+++ b/tests/encoders/text/test_spacy_encoder.py
@@ -28,7 +28,7 @@ def test_spacy_encoder_issue_44():
 
 
 def test_spacy_encoder_batch(encoder, input_):
-    tokens = encoder.batch_encode([input_, input_])
+    tokens, _ = encoder.batch_encode([input_, input_])
     assert encoder.decode(tokens[0]) == input_
     assert encoder.decode(tokens[1]) == input_
 

--- a/torchnlp/__init__.py
+++ b/torchnlp/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '0.4.0.post2'
+__version__ = '0.4.1'

--- a/torchnlp/encoders/encoder.py
+++ b/torchnlp/encoders/encoder.py
@@ -1,86 +1,70 @@
-import torch
-
-
 class Encoder(object):
-    """ Base class for a encoder.
+    """
+    Base class for a encoder.
+
+    Args:
+        enforce_reversible (bool): Check for reversibility on ``Encoder.encode`` and
+          ``Encoder.decode``. Formally, reversible means:
+          ``Encoder.decode(Encoder.encode(object_)) == object_``.
     """
 
-    def __init__(self):  # pragma: no cover
-        raise NotImplementedError
+    def __init__(self, enforce_reversible=False):
+        self.enforce_reversible = enforce_reversible
 
-    def enforce_reversible(self):
-        """ Updates the specification of ``Encoder.encode`` and ``Encoder.decode`` to enforce
-        reversibility.
-
-        Formally, reversible means: ``Encoder.decode(Encoder.encode(object_)) == object_``
-
-        Example:
-            >>> encoder = Encoder().enforce_reversible()  # doctest: +SKIP
-        """
-        last_encode = self.encode
-        last_decode = self.decode
-
-        def _encode(object_, *args, **kwargs):
-            encoded = last_encode(object_, *args, **kwargs)
-            if last_decode(encoded) != object_:
-                raise ValueError('Encoding is not reversible for "%s"' % object_)
-            return encoded
-
-        self.encode = _encode
-
-        def _decode(tensor, *args, **kwargs):
-            decoded = last_decode(tensor, *args, **kwargs)
-            if last_encode(decoded) != tensor:
-                raise ValueError('Decode is not reversible for "%s"' % tensor)
-            return decoded
-
-        self.decode = _decode
-        return self
-
-    def encode(self, object_):  # pragma: no cover
-        """ Encodes an object to a :class:`torch.Tensor`.
+    def encode(self, object_):
+        """ Encodes an object.
 
         Args:
             object_ (object): Object to encode.
 
         Returns:
-            torch.Tensor: Encoding of the object.
+            object: Encoding of the object.
         """
-        raise NotImplementedError
+        if self.enforce_reversible:
+            self.enforce_reversible = False
+            if self.decode(self.encode(object_)) != object_:
+                raise ValueError('Encoding is not reversible for "%s"' % object_)
+            self.enforce_reversible = True
 
-    def batch_encode(self, batch, *args, **kwargs):
+        return object_
+
+    def batch_encode(self, iterator, *args, **kwargs):
         """
         Args:
             batch (list): Batch of objects to encode.
             *args: Arguments passed to ``encode``.
-            **kwargs: Key word arguments passed to ``encode``.
+            **kwargs: Keyword arguments passed to ``encode``.
 
         Returns:
             list: Batch of encoded objects.
         """
-        return torch.tensor([self.encode(object_, *args, **kwargs).tolist() for object_ in batch])
+        return [self.encode(object_, *args, **kwargs) for object_ in iterator]
 
-    def decode(self, tensor):  # pragma: no cover
-        """ Decodes a :class:`torch.Tensor` to a object.
+    def decode(self, encoded):
+        """ Decodes an object.
 
         Args:
-            tensor (torch.Tensor): Tensor to decode.
+            object_ (object): Encoded object.
 
         Returns:
-            object: Object decoded from tensor.
+            object: Object decoded.
         """
-        raise NotImplementedError
+        if self.enforce_reversible:
+            self.enforce_reversible = False
+            if self.encode(self.decode(encoded)) != encoded:
+                raise ValueError('Decoding is not reversible for "%s"' % encoded)
+            self.enforce_reversible = True
 
-    def batch_decode(self, batch, *args, **kwargs):
+        return encoded
+
+    def batch_decode(self, iterator, *args, **kwargs):
         """
         Args:
-            batch (list of :class:`torch.Tensor`): Batch of encoded objects.
+            iterator (list): Batch of encoded objects.
             *args: Arguments passed to ``decode``.
-            **kwargs: Key word arguments passed to ``decode``.
+            **kwargs: Keyword arguments passed to ``decode``.
 
         Returns:
             list: Batch of decoded objects.
         """
-        iterator = ([split.squeeze(0) for split in batch.split(1)]
-                    if torch.is_tensor(batch) else batch)
-        return [self.decode(tensor, *args, **kwargs) for tensor in iterator]
+        return [self.decode(encoded, *args, **kwargs) for encoded in iterator]

--- a/torchnlp/encoders/encoder.py
+++ b/torchnlp/encoders/encoder.py
@@ -1,9 +1,9 @@
 class Encoder(object):
     """
-    Base class for a encoder.
+    Base class for a encoder employing an identity function.
 
     Args:
-        enforce_reversible (bool): Check for reversibility on ``Encoder.encode`` and
+        enforce_reversible (bool, optional): Check for reversibility on ``Encoder.encode`` and
           ``Encoder.decode``. Formally, reversible means:
           ``Encoder.decode(Encoder.encode(object_)) == object_``.
     """

--- a/torchnlp/encoders/text/character_encoder.py
+++ b/torchnlp/encoders/text/character_encoder.py
@@ -5,30 +5,23 @@ def _tokenize(s):
     return list(s)
 
 
+def _detokenize(s):
+    return ''.join(s)
+
+
 class CharacterEncoder(StaticTokenizerEncoder):
     """ Encodes text into a tensor by splitting the text into individual characters.
 
     Args:
-        sample (list): Sample of data used to build encoding dictionary.
-        min_occurrences (int, optional): Minimum number of occurrences for a token to be added to
-          the encoding dictionary.
-        append_eos (bool, optional): If ``True`` append EOS token onto the end to the encoded
-          vector.
-        reserved_tokens (list of str, optional): List of reserved tokens inserted in the beginning
-            of the dictionary.
-        eos_index (int, optional): The eos token is used to encode the end of a sequence. This is
-          the index that token resides at.
-        unknown_index (int, optional): The unknown token is used to encode unseen tokens. This is
-          the index that token resides at.
-        padding_index (int, optional): The unknown token is used to encode sequence padding. This is
-          the index that token resides at.
+        **args: Arguments passed onto ``StaticTokenizerEncoder.__init__``.
+        **kwargs: Keyword arguments passed onto ``StaticTokenizerEncoder.__init__``.
     """
 
     def __init__(self, *args, **kwargs):
         if 'tokenize' in kwargs:
-            raise TypeError('Encoder does not take keyword argument tokenize.')
+            raise TypeError('``CharacterEncoder`` does not take keyword argument ``tokenize``.')
 
-        super().__init__(*args, tokenize=_tokenize, **kwargs)
+        if 'detokenize' in kwargs:
+            raise TypeError('``CharacterEncoder`` does not take keyword argument ``detokenize``.')
 
-    def decode(self, tensor):
-        return ''.join([self.itos[index] for index in tensor])
+        super().__init__(*args, tokenize=_tokenize, detokenize=_detokenize, **kwargs)

--- a/torchnlp/encoders/text/delimiter_encoder.py
+++ b/torchnlp/encoders/text/delimiter_encoder.py
@@ -7,25 +7,17 @@ def _tokenize(s, delimiter):
     return s.split(delimiter)
 
 
+def _detokenize(s, delimiter):
+    return delimiter.join(s)
+
+
 class DelimiterEncoder(StaticTokenizerEncoder):
     """ Encodes text into a tensor by splitting the text using a delimiter.
 
     Args:
-        delimiter (string): Delimiter used with ``string.split``
-        sample (list): Sample of data used to build encoding dictionary.
-        min_occurrences (int, optional): Minimum number of occurrences for a token to be added to
-          the encoding dictionary.
-        append_eos (bool, optional): If ``True`` append EOS token onto the end to the encoded
-          vector.
-        reserved_tokens (list of str, optional): List of reserved tokens inserted in the beginning
-            of the dictionary.
-        eos_index (int, optional): The eos token is used to encode the end of a sequence. This is
-          the index that token resides at.
-        unknown_index (int, optional): The unknown token is used to encode unseen tokens. This is
-          the index that token resides at.
-        padding_index (int, optional): The unknown token is used to encode sequence padding. This is
-          the index that token resides at.
-
+        delimiter (string): Delimiter used with ``string.split``.
+        **args: Arguments passed onto ``StaticTokenizerEncoder.__init__``.
+        **kwargs: Keyword arguments passed onto ``StaticTokenizerEncoder.__init__``.
 
     Example:
 
@@ -39,10 +31,15 @@ class DelimiterEncoder(StaticTokenizerEncoder):
 
     def __init__(self, delimiter, *args, **kwargs):
         if 'tokenize' in kwargs:
-            raise TypeError('Encoder does not take keyword argument tokenize.')
+            raise TypeError('``DelimiterEncoder`` does not take keyword argument ``tokenize``.')
+
+        if 'detokenize' in kwargs:
+            raise TypeError('``DelimiterEncoder`` does not take keyword argument ``detokenize``.')
 
         self.delimiter = delimiter
-        super().__init__(*args, tokenize=partial(_tokenize, delimiter=self.delimiter), **kwargs)
 
-    def decode(self, tensor):
-        return self.delimiter.join([self.itos[index] for index in tensor])
+        super().__init__(
+            *args,
+            tokenize=partial(_tokenize, delimiter=self.delimiter),
+            detokenize=partial(_detokenize, delimiter=self.delimiter),
+            **kwargs)

--- a/torchnlp/encoders/text/moses_encoder.py
+++ b/torchnlp/encoders/text/moses_encoder.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 from torchnlp.encoders.text.static_tokenizer_encoder import StaticTokenizerEncoder
 
 
@@ -8,19 +10,8 @@ class MosesEncoder(StaticTokenizerEncoder):
     http://www.nltk.org/_modules/nltk/tokenize/moses.html
 
     Args:
-        sample (list): Sample of data used to build encoding dictionary.
-        min_occurrences (int, optional): Minimum number of occurrences for a token to be added to
-          the encoding dictionary.
-        append_eos (bool, optional): If ``True`` append EOS token onto the end to the encoded
-          vector.
-        reserved_tokens (list of str, optional): List of reserved tokens inserted in the beginning
-            of the dictionary.
-        eos_index (int, optional): The eos token is used to encode the end of a sequence. This is
-          the index that token resides at.
-        unknown_index (int, optional): The unknown token is used to encode unseen tokens. This is
-          the index that token resides at.
-        padding_index (int, optional): The unknown token is used to encode sequence padding. This is
-          the index that token resides at.
+        **args: Arguments passed onto ``StaticTokenizerEncoder.__init__``.
+        **kwargs: Keyword arguments passed onto ``StaticTokenizerEncoder.__init__``.
 
     Example:
 
@@ -37,7 +28,10 @@ class MosesEncoder(StaticTokenizerEncoder):
 
     def __init__(self, *args, **kwargs):
         if 'tokenize' in kwargs:
-            raise TypeError('Encoder does not take keyword argument tokenize.')
+            raise TypeError('``MosesEncoder`` does not take keyword argument ``tokenize``.')
+
+        if 'detokenize' in kwargs:
+            raise TypeError('``MosesEncoder`` does not take keyword argument ``detokenize``.')
 
         try:
             from sacremoses import MosesTokenizer
@@ -47,10 +41,8 @@ class MosesEncoder(StaticTokenizerEncoder):
                   "See the docs at https://github.com/alvations/sacremoses for more information.")
             raise
 
-        self.detokenizer = MosesDetokenizer()
-
-        super().__init__(*args, tokenize=MosesTokenizer().tokenize, **kwargs)
-
-    def decode(self, tensor):
-        tokens = [self.itos[index] for index in tensor]
-        return self.detokenizer.detokenize(tokens, return_str=True)
+        super().__init__(
+            *args,
+            tokenize=MosesTokenizer().tokenize,
+            detokenize=partial(MosesDetokenizer().detokenize, return_str=True),
+            **kwargs)

--- a/torchnlp/encoders/text/static_tokenizer_encoder.py
+++ b/torchnlp/encoders/text/static_tokenizer_encoder.py
@@ -13,6 +13,10 @@ def _tokenize(s):
     return s.split()
 
 
+def _detokenize(t):
+    return ' '.join(t)
+
+
 class StaticTokenizerEncoder(TextEncoder):
     """ Encodes a text sequence using a static tokenizer.
 
@@ -20,7 +24,8 @@ class StaticTokenizerEncoder(TextEncoder):
         sample (list): Sample of data used to build encoding dictionary.
         min_occurrences (int, optional): Minimum number of occurrences for a token to be added to
           the encoding dictionary.
-        tokenize (callable): :class:``callable`` to tokenize a sequence.
+        tokenize (callable): :class:`callable` to tokenize a sequence.
+        detokenize (callable): :class:`callable` to detokenize a sequence.
         append_eos (bool, optional): If ``True`` append EOS token onto the end to the encoded
           vector.
         reserved_tokens (list of str, optional): List of reserved tokens inserted in the beginning
@@ -31,6 +36,7 @@ class StaticTokenizerEncoder(TextEncoder):
           the index that token resides at.
         padding_index (int, optional): The unknown token is used to encode sequence padding. This is
           the index that token resides at.
+        **kwargs: Keyword arguments passed onto ``TextEncoder.__init__``.
 
     Example:
 
@@ -50,10 +56,14 @@ class StaticTokenizerEncoder(TextEncoder):
                  min_occurrences=1,
                  append_eos=False,
                  tokenize=_tokenize,
+                 detokenize=_detokenize,
                  reserved_tokens=DEFAULT_RESERVED_TOKENS,
                  eos_index=DEFAULT_EOS_INDEX,
                  unknown_index=DEFAULT_UNKNOWN_INDEX,
-                 padding_index=DEFAULT_PADDING_INDEX):
+                 padding_index=DEFAULT_PADDING_INDEX,
+                 **kwargs):
+        super().__init__(**kwargs)
+
         if not isinstance(sample, list):
             raise TypeError('Sample must be a list.')
 
@@ -62,6 +72,7 @@ class StaticTokenizerEncoder(TextEncoder):
         self.padding_index = padding_index
         self.reserved_tokens = reserved_tokens
         self.tokenize = tokenize
+        self.detokenize = detokenize
         self.append_eos = append_eos
         self.tokens = Counter()
 
@@ -92,12 +103,30 @@ class StaticTokenizerEncoder(TextEncoder):
         return len(self.vocab)
 
     def encode(self, sequence):
+        """ Encodes a ``sequence``.
+
+        Args:
+            sequence (str): String ``sequence`` to encode.
+
+        Returns:
+            torch.Tensor: Encoding of the ``sequence``.
+        """
+        sequence = super().encode(sequence)
         sequence = self.tokenize(sequence)
         vector = [self.stoi.get(token, self.unknown_index) for token in sequence]
         if self.append_eos:
             vector.append(self.eos_index)
         return torch.tensor(vector)
 
-    def decode(self, tensor):
-        tokens = [self.itos[index] for index in tensor]
-        return ' '.join(tokens)
+    def decode(self, encoded):
+        """ Decodes a tensor into a sequence.
+
+        Args:
+            encoded (torch.Tensor): Encoded sequence.
+
+        Returns:
+            str: Sequence decoded from ``encoded``.
+        """
+        encoded = super().decode(encoded)
+        tokens = [self.itos[index] for index in encoded]
+        return self.detokenize(tokens)

--- a/torchnlp/encoders/text/subword_encoder.py
+++ b/torchnlp/encoders/text/subword_encoder.py
@@ -24,7 +24,7 @@ class SubwordEncoder(TextEncoder):
     Args:
         sample (list): Sample of data used to build encoding dictionary.
         append_eos (bool, optional): If ``True`` append EOS token onto the end to the encoded
-          vector.
+            vector.
         target_vocab_size (int, optional): Desired size of vocab.
         min_occurrences (int, optional): Lower bound for the minimum token count.
         max_occurrences (int, optional): Upper bound for the minimum token count.

--- a/torchnlp/encoders/text/subword_encoder.py
+++ b/torchnlp/encoders/text/subword_encoder.py
@@ -36,6 +36,7 @@ class SubwordEncoder(TextEncoder):
           the index that token resides at.
         padding_index (int, optional): The unknown token is used to encode sequence padding. This is
           the index that token resides at.
+        **kwargs: Keyword arguments passed onto ``TextEncoder.__init__``.
     """
 
     def __init__(self,
@@ -47,7 +48,10 @@ class SubwordEncoder(TextEncoder):
                  reserved_tokens=DEFAULT_RESERVED_TOKENS,
                  eos_index=DEFAULT_EOS_INDEX,
                  unknown_index=DEFAULT_UNKNOWN_INDEX,
-                 padding_index=DEFAULT_PADDING_INDEX):
+                 padding_index=DEFAULT_PADDING_INDEX,
+                 **kwargs):
+        super().__init__(**kwargs)
+
         self.append_eos = append_eos
         self.eos_index = eos_index
         self.unknown_index = unknown_index
@@ -89,11 +93,29 @@ class SubwordEncoder(TextEncoder):
         return len(self.vocab)
 
     def encode(self, sequence):
+        """ Encodes a ``sequence``.
+
+        Args:
+            sequence (str): String ``sequence`` to encode.
+
+        Returns:
+            torch.Tensor: Encoding of the ``sequence``.
+        """
+        sequence = super().encode(sequence)
         sequence = self.tokenizer.encode(sequence)
         vector = [self.stoi.get(token, self.unknown_index) for token in sequence]
         if self.append_eos:
             vector.append(self.eos_index)
         return torch.tensor(vector)
 
-    def decode(self, tensor):
-        return self.tokenizer.decode([self.itos[index] for index in tensor])
+    def decode(self, encoded):
+        """ Decodes a tensor into a sequence.
+
+        Args:
+            encoded (torch.Tensor): Encoded sequence.
+
+        Returns:
+            str: Sequence decoded from ``encoded``.
+        """
+        encoded = super().decode(encoded)
+        return self.tokenizer.decode([self.itos[index] for index in encoded])

--- a/torchnlp/encoders/text/text_encoder.py
+++ b/torchnlp/encoders/text/text_encoder.py
@@ -55,8 +55,8 @@ class TextEncoder(Encoder):
             **kwargs: Keyword arguments passed onto ``Encoder.__init__``.
 
         Returns
-            torch.Tensor, list of int: Encoded and padded batch of sequences;
-                Original lengths of sequences.
+            torch.Tensor, list of int: Encoded and padded batch of sequences; Original lengths of
+                sequences.
         """
         return stack_and_pad_tensors(
             super().batch_encode(iterator), padding_index=self.padding_index, dim=dim)

--- a/torchnlp/encoders/text/text_encoder.py
+++ b/torchnlp/encoders/text/text_encoder.py
@@ -46,31 +46,32 @@ def stack_and_pad_tensors(batch, padding_index=DEFAULT_PADDING_INDEX, dim=0):
 
 class TextEncoder(Encoder):
 
-    def batch_encode(self, batch, *args, dim=0, **kwargs):
+    def batch_encode(self, iterator, *args, dim=0, **kwargs):
         """
-        Returns
-            torch.Tensor: Encoded and padded batch of sequences.
-            list of int: Original lengths of sequences.
-        """
-        return stack_and_pad_tensors([self.encode(object_, *args, **kwargs) for object_ in batch],
-                                     padding_index=self.padding_index,
-                                     dim=dim)
+        Args:
+            iterator (iterator): Batch of text to encode.
+            *args: Arguments passed onto ``Encoder.__init__``.
+            dim (int, optional): Dimension along which to concatenate tensors.
+            **kwargs: Keyword arguments passed onto ``Encoder.__init__``.
 
-    def batch_decode(self, batch, lengths=None, *args, **kwargs):
+        Returns
+            torch.Tensor, list of int: Encoded and padded batch of sequences;
+                Original lengths of sequences.
+        """
+        return stack_and_pad_tensors(
+            super().batch_encode(iterator), padding_index=self.padding_index, dim=dim)
+
+    def batch_decode(self, tensor, lengths, dim=0, *args, **kwargs):
         """
         Args:
             batch (list of :class:`torch.Tensor`): Batch of encoded sequences.
             lengths (list of int): Original lengths of sequences.
+            dim (int, optional): Dimension along which to split tensors.
             *args: Arguments passed to ``decode``.
             **kwargs: Key word arguments passed to ``decode``.
 
         Returns:
             list: Batch of decoded sequences.
         """
-        split = batch.split(1) if torch.is_tensor(batch) else batch
-        decoded = []
-        for i, text in enumerate(split):
-            text = text.squeeze(0) if torch.is_tensor(batch) else text
-            text = text[:lengths[i]] if lengths is not None else text
-            decoded.append(self.decode(text, *args, **kwargs))
-        return decoded
+        return super().batch_decode(
+            [t.squeeze(0)[:l] for t, l in zip(tensor.split(1, dim=dim), lengths)])

--- a/torchnlp/encoders/text/treebank_encoder.py
+++ b/torchnlp/encoders/text/treebank_encoder.py
@@ -8,19 +8,8 @@ class TreebankEncoder(StaticTokenizerEncoder):
     http://www.nltk.org/_modules/nltk/tokenize/treebank.html
 
     Args:
-        sample (list): Sample of data used to build encoding dictionary.
-        min_occurrences (int, optional): Minimum number of occurrences for a token to be added to
-          the encoding dictionary.
-        append_eos (bool, optional): If ``True`` append EOS token onto the end to the encoded
-          vector.
-        reserved_tokens (list of str, optional): List of reserved tokens inserted in the beginning
-            of the dictionary.
-        eos_index (int, optional): The eos token is used to encode the end of a sequence. This is
-          the index that token resides at.
-        unknown_index (int, optional): The unknown token is used to encode unseen tokens. This is
-          the index that token resides at.
-        padding_index (int, optional): The unknown token is used to encode sequence padding. This is
-          the index that token resides at.
+        **args: Arguments passed onto ``StaticTokenizerEncoder.__init__``.
+        **kwargs: Keyword arguments passed onto ``StaticTokenizerEncoder.__init__``.
 
     Example:
 
@@ -36,7 +25,10 @@ class TreebankEncoder(StaticTokenizerEncoder):
 
     def __init__(self, *args, **kwargs):
         if 'tokenize' in kwargs:
-            raise TypeError('Encoder does not take keyword argument tokenize.')
+            raise TypeError('``TreebankEncoder`` does not take keyword argument ``tokenize``.')
+
+        if 'detokenize' in kwargs:
+            raise TypeError('``TreebankEncoder`` does not take keyword argument ``detokenize``.')
 
         try:
             import nltk
@@ -51,10 +43,8 @@ class TreebankEncoder(StaticTokenizerEncoder):
             print("Please install NLTK. " "See the docs at http://nltk.org for more information.")
             raise
 
-        self.detokenizer = TreebankWordDetokenizer()
-
-        super().__init__(*args, tokenize=TreebankWordTokenizer().tokenize, **kwargs)
-
-    def decode(self, tensor):
-        tokens = [self.itos[index] for index in tensor]
-        return self.detokenizer.detokenize(tokens)
+        super().__init__(
+            *args,
+            tokenize=TreebankWordTokenizer().tokenize,
+            detokenize=TreebankWordDetokenizer().detokenize,
+            **kwargs)

--- a/torchnlp/encoders/text/whitespace_encoder.py
+++ b/torchnlp/encoders/text/whitespace_encoder.py
@@ -5,19 +5,8 @@ class WhitespaceEncoder(DelimiterEncoder):
     """ Encodes a text by splitting on whitespace.
 
     Args:
-        sample (list): Sample of data used to build encoding dictionary.
-        min_occurrences (int, optional): Minimum number of occurrences for a token to be added to
-          the encoding dictionary.
-        append_eos (bool, optional): If ``True`` append EOS token onto the end to the encoded
-          vector.
-        reserved_tokens (list of str, optional): List of reserved tokens inserted in the beginning
-            of the dictionary.
-        eos_index (int, optional): The eos token is used to encode the end of a sequence. This is
-          the index that token resides at.
-        unknown_index (int, optional): The unknown token is used to encode unseen tokens. This is
-          the index that token resides at.
-        padding_index (int, optional): The unknown token is used to encode sequence padding. This is
-          the index that token resides at.
+        **args: Arguments passed onto ``DelimiterEncoder.__init__``.
+        **kwargs: Keyword arguments passed onto ``DelimiterEncoder.__init__``.
 
     Example:
 


### PR DESCRIPTION
Updates:
- ``enforce_reversible`` specification has changed from a function to a property.
- ``spacy.batch_encode`` now consistently returns ``length`` along with the encoded object.
- More code reuse through object orientated programming.
- Loosened up the specification for ``Encoder`` to return objects rather than Tensors.


