### PR TITLE
Fix: Doc for FastText

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ from torchnlp.word_to_vector import FastText
 
 vectors = FastText()
 # Load vectors for any word as a `torch.FloatTensor`
-vectors['hello']  # RETURNS: [torch.FloatTensor of size 100]
+vectors['hello']  # RETURNS: [torch.FloatTensor of size 300]
 ```
 
 ### Compute [Metrics](http://pytorchnlp.readthedocs.io/en/latest/source/torchnlp.metrics.html)

--- a/torchnlp/word_to_vector/fast_text.py
+++ b/torchnlp/word_to_vector/fast_text.py
@@ -64,12 +64,12 @@ class FastText(_PretrainedWordVectors):
         >>> from torchnlp.word_to_vector import FastText  # doctest: +SKIP
         >>> vectors = FastText()  # doctest: +SKIP
         >>> vectors['hello']  # doctest: +SKIP
-        -1.7494
-        0.6242
+        -0.1595
+        -0.1826
         ...
-        -0.6202
-        2.0928
-        [torch.FloatTensor of size 100]
+        0.2492
+        0.0654
+        [torch.FloatTensor of size 300]
     """
     url_base = 'https://dl.fbaipublicfiles.com/fasttext/vectors-wiki/wiki.{}.vec'
     aligned_url_base = 'https://dl.fbaipublicfiles.com/fasttext/vectors-aligned/wiki.{}.align.vec'


### PR DESCRIPTION
The pretrained vectors according to the official document[https://github.com/facebookresearch/fastText/blob/master/docs/pretrained-vectors.md] are in dimension 300.

> We are publishing pre-trained word vectors for 294 languages, trained on Wikipedia using fastText. These vectors in dimension 300 were obtained using the skip-gram model described in Bojanowski et al. (2016) with default parameters.

Also in this implementation, FastText class return 100 dimension vectors.