### PR TITLE
Replaced .view with .reshape on Attention

### DIFF
--- a/torchnlp/nn/attention.py
+++ b/torchnlp/nn/attention.py
@@ -61,9 +61,9 @@ class Attention(nn.Module):
         query_len = context.size(1)
 
         if self.attention_type == "general":
-            query = query.view(batch_size * output_len, dimensions)
+            query = query.reshape(batch_size * output_len, dimensions)
             query = self.linear_in(query)
-            query = query.view(batch_size, output_len, dimensions)
+            query = query.reshape(batch_size, output_len, dimensions)
 
         # TODO: Include mask on PADDING_INDEX?
 


### PR DESCRIPTION
Replaced .view with .reshape in Attention module in order to avoid RuntimeError: "view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.".